### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[jstrachan/bdd-nh-1582910159](https://github.com/jstrachan/bdd-nh-1582910159.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jstrachan/bdd-nh-1582910244](https://github.com/jstrachan/bdd-nh-1582910244.git) |  | []() | 
+[jstrachan/bdd-nh-1582911519](https://github.com/jstrachan/bdd-nh-1582911519.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,4 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jstrachan/bdd-nh-1582910159](https://github.com/jstrachan/bdd-nh-1582910159.git) |  | []() | 
+[jstrachan/bdd-nh-1582910244](https://github.com/jstrachan/bdd-nh-1582910244.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: jstrachan
+  repo: bdd-nh-1582910159
+  url: https://github.com/jstrachan/bdd-nh-1582910159.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jstrachan
-  repo: bdd-nh-1582910244
-  url: https://github.com/jstrachan/bdd-nh-1582910244.git
+  repo: bdd-nh-1582911519
+  url: https://github.com/jstrachan/bdd-nh-1582911519.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - host: github.com
   owner: jstrachan
-  repo: bdd-nh-1582910159
-  url: https://github.com/jstrachan/bdd-nh-1582910159.git
+  repo: bdd-nh-1582910244
+  url: https://github.com/jstrachan/bdd-nh-1582910244.git
   version: ""
   versionURL: ""

--- a/repositories/templates/jstrachan-bdd-nh-1582910159-sr.yaml
+++ b/repositories/templates/jstrachan-bdd-nh-1582910159-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: bdd-nh-1582910159
+  name: jstrachan-bdd-nh-1582910159
+spec:
+  description: Imported application for jstrachan/bdd-nh-1582910159
+  httpCloneURL: https://github.com/jstrachan/bdd-nh-1582910159.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: bdd-nh-1582910159
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/bdd-nh-1582910159.git

--- a/repositories/templates/jstrachan-bdd-nh-1582910244-sr.yaml
+++ b/repositories/templates/jstrachan-bdd-nh-1582910244-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: bdd-nh-1582910244
+  name: jstrachan-bdd-nh-1582910244
+spec:
+  description: Imported application for jstrachan/bdd-nh-1582910244
+  httpCloneURL: https://github.com/jstrachan/bdd-nh-1582910244.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: bdd-nh-1582910244
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/bdd-nh-1582910244.git

--- a/repositories/templates/jstrachan-bdd-nh-1582911519-sr.yaml
+++ b/repositories/templates/jstrachan-bdd-nh-1582911519-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jstrachan
+    provider: github
+    repository: bdd-nh-1582911519
+  name: jstrachan-bdd-nh-1582911519
+spec:
+  description: Imported application for jstrachan/bdd-nh-1582911519
+  httpCloneURL: https://github.com/jstrachan/bdd-nh-1582911519.git
+  org: jstrachan
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: bdd-nh-1582911519
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/jstrachan/bdd-nh-1582911519.git


### PR DESCRIPTION
Update [jstrachan/bdd-nh-1582911519](https://github.com/jstrachan/bdd-nh-1582911519.git) 

Command run was `jx create quickstart -b --org jstrachan -p bdd-nh-1582911519 -f node-http --git-provider-url https://github.com`
<hr />

Update [jstrachan/bdd-nh-1582910244](https://github.com/jstrachan/bdd-nh-1582910244.git) 

Command run was `jx create quickstart -b --org jstrachan -p bdd-nh-1582910244 -f node-http --git-provider-url https://github.com`
<hr />

Update [jstrachan/bdd-nh-1582910159](https://github.com/jstrachan/bdd-nh-1582910159.git) 

Command run was `jx create quickstart -b --org jstrachan -p bdd-nh-1582910159 -f node-http --git-provider-url https://github.com`